### PR TITLE
Lumnn/feature syntax

### DIFF
--- a/GitDiffView.sublime-settings
+++ b/GitDiffView.sublime-settings
@@ -1,12 +1,7 @@
 {
-    // Changes how file list is coloured.
-    // Requires restart
-    //
-    // - Packages/GitDiffView/syntax/GitStatus.sublime-syntax  
-    //     Default Theme - colored are only symbols.
-    // - Packages/GitDiffView/syntax/GitStatusFancy.sublime-syntax  
-    //     Apart from colouring symbols it colours file names, and greys out
-    //     file paths
-    "file_list_syntax_definition": "Packages/GitDiffView/syntax/GitStatus.sublime-syntax",
-    "staged_symbol": "■"
+    "staged_symbol": "■",
+    "unstaged_symbol": "☐",
+
+    // this settings change requires a restart
+    "highlight_file_names": false
 }

--- a/README.md
+++ b/README.md
@@ -56,15 +56,13 @@ For other Git commands, like commiting, pushing, pulling, see [Git](https://gith
 
 ### Configuration
 
-#### Theme
-
-2 themes are available by default and can be changed in settings.
+You can turn on highlight file names in git status view by setting `"highlight_file_names": true` in
 `Preferences > Package Settings > GitDiffView > Settings`
 
-##### Default theme
-
-![Default theme](img/theme-default.png)
-
-##### Fancy theme
+`highlight_file_names: true`
 
 ![Fancy theme](img/theme-fancy.png)
+
+`highlight_file_names: false`
+
+![Default theme](img/theme-default.png)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For other Git commands, like commiting, pushing, pulling, see [Git](https://gith
 ### Configuration
 
 You can turn on highlight file names in git status view by setting `"highlight_file_names": true` in
-`Preferences > Package Settings > GitDiffView > Settings`
+`Preferences > Package Settings > GitDiffView > Settings`.
 
 `highlight_file_names: true`
 

--- a/core/Formated.py
+++ b/core/Formated.py
@@ -13,8 +13,8 @@ class Formated:
         formated_output = []
 
         settings = sublime.load_settings("GitDiffView.sublime-settings")
-        staged = settings.get('staged_symbol');
-        unstaged = ' ';
+        staged = settings.get('staged_symbol', '■')
+        unstaged = settings.get('unstaged_symbol', '☐')
 
         for status in git_statuses:
             staged_status = staged if status['is_staged'] else unstaged

--- a/core/GitStatusView.py
+++ b/core/GitStatusView.py
@@ -47,8 +47,14 @@ class GitStatusView:
 
     def _configure_view(self, view):
         settings = sublime.load_settings("GitDiffView.sublime-settings")
-        file_list_syntax_definition = settings.get('file_list_syntax_definition', 'Packages/GitDiffView/syntax/GitStatus.sublime-syntax')
-        view.set_syntax_file(file_list_syntax_definition)
+
+        default_sytnax = "Packages/GitDiffView/syntax/GitStatus.sublime-syntax"
+        fancy_sytnax = "Packages/GitDiffView/syntax/GitStatusFancy.sublime-syntax"
+
+        highlight_file_names = settings.get("highlight_file_names", False)
+        syntax = fancy_sytnax if highlight_file_names else default_sytnax
+
+        view.set_syntax_file(syntax)
 
         view.settings().set('highlight_line', True)
         view.settings().set("line_numbers", False)

--- a/syntax/GitStatus.sublime-syntax
+++ b/syntax/GitStatus.sublime-syntax
@@ -8,22 +8,22 @@ scope: text.gsf   # Used to add scopes to the Git Status View
 
 contexts:
   main:
-    - match: '[^ ]\s+\b(M|MM)\b'
+    - match: '[^☐]\s+\b(M|MM)\b'
       scope: markup.changed
 
-    - match: '[^ ]\s+\b(UU)\b'
+    - match: '[^☐]\s+\b(UU)\b'
       scope: markup.changed
 
-    - match: '[^ ]\s+\b(A)\b'
+    - match: '[^☐]\s+\b(A)\b'
       scope: markup.inserted
 
-    - match: '[^ ]\s+\b(D)\b'
+    - match: '[^☐]\s+\b(D)\b'
       scope: markup.deleted
 
-    - match: '[^ ]\s+\b(R)\b'
+    - match: '[^☐]\s+\b(R)\b'
       scope: markup.changed
 
-    - match: '[^ ]\s+\b(C)\b'
+    - match: '[^☐]\s+\b(C)\b'
       scope: markup.changed
 
     - match: (\?\?)


### PR DESCRIPTION
Hello can you see the changes I made to your PR.
- added `highlight_file_names` boolean setting, instead of the prevous setting that required the syntax to be passed in.
- added `unstaged_symbol` setting.
- changed GItStatusSyntax, so it doesn't  color this `☐` in `☐ M` when not staged

<img width="363" alt="Screenshot 2019-11-21 at 21 16 49" src="https://user-images.githubusercontent.com/22029477/69375323-5ba80b00-0ca8-11ea-91ba-631cd8aa358a.png">


BTW, great job for highlighting untracked files.